### PR TITLE
please check MAX_IMAGE_CACHE_ENTRIES

### DIFF
--- a/src/com/github/volley_examples/app/MyVolley.java
+++ b/src/com/github/volley_examples/app/MyVolley.java
@@ -43,6 +43,21 @@ public class MyVolley {
 
     static void init(Context context) {
         mRequestQueue = Volley.newRequestQueue(context);
+        /* 
+         * Thanks to your sample codes. but.
+         * please check MAX_IMAGE_CACHE_ENTRIES .. (I'm not meaning it's spelled)
+         * you overrided sizeOf method in BitmapLruCache class that returns size of entry(bitmap).
+         * but here you define maxSize to 100, that means set cache size to 100 byte.
+         * So, no image can cache to LruCache.
+         * Remove sizeOf method in BitmaplruCache class, 
+         * or change max_image_cache_entries to some memory size like this.
+         * int memClass = ((ActivityManager) ctx.getSystemService(Context.ACTIVITY_SERVICE)).getMemoryClass();
+		 *	// Use 1/8th of the available memory for this memory cache.
+		 *	int cacheSize = 1024 * 1024 * memClass / 8;
+		 * mImageLoader = new ImageLoader(mRequestQueue, new BitmapLruCache(MAX_IMAGE_CACHE_ENTIRES));
+		 * 
+		 */
+		 //TODO please check MAX_IMAGE_CACHE_ENTIRES
         mImageLoader = new ImageLoader(mRequestQueue, new BitmapLruCache(MAX_IMAGE_CACHE_ENTIRES));
     }
 


### PR DESCRIPTION
Thanks to your sample codes. but.
please check MAX_IMAGE_CACHE_ENTRIES .. (I'm not meaning it's spelled)
you overrided sizeOf method in BitmapLruCache class that returns size of entry(bitmap).
but here you define maxSize to 100, that means set cache size to 100 byte.
So, no image can cache to LruCache.
Remove sizeOf method in BitmaplruCache class, 
or change max_image_cache_entries to some memory size like this.
int memClass = ((ActivityManager) ctx.getSystemService(Context.ACTIVITY_SERVICE)).getMemoryClass();
// Use 1/8th of the available memory for this memory cache.
int cacheSize = 1024 \* 1024 \* memClass / 8;
mImageLoader = new ImageLoader(mRequestQueue, new BitmapLruCache(MAX_IMAGE_CACHE_ENTIRES));
